### PR TITLE
Fixed missing description in timepoint_unit field

### DIFF
--- a/json_schema/type/biomaterial/differentiated_cell_line.json
+++ b/json_schema/type/biomaterial/differentiated_cell_line.json
@@ -133,6 +133,7 @@
                     "type": "string",
                     "minLength": 1,
                     "title": "Timepoint unit",
+                    "description": "Unit of the timepoint.",
                     "graphRestriction": {
                         "ontologies": [
                             "obo:uo"

--- a/json_schema/type/biomaterial/undifferentiated_product.json
+++ b/json_schema/type/biomaterial/undifferentiated_product.json
@@ -67,6 +67,7 @@
           "type": "string",
           "minLength": 1,
           "title": "Timepoint unit",
+          "description": "Unit of the timepoint.",
           "graphRestriction": {
             "ontologies": [
               "obo:uo"

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -11,10 +11,10 @@
       "biomaterial": {
         "cell_line": "1.0.0",
         "clonal_cell_line": "2.0.0",
-        "differentiated_cell_line": "1.0.0",
+        "differentiated_cell_line": "1.0.1",
         "library_preparation": "1.0.0",
         "organoid": "1.0.0",
-        "undifferentiated_product": "1.0.0"
+        "undifferentiated_product": "1.0.1"
       },
       "file": {
         "analysis_file": "1.0.0",


### PR DESCRIPTION
For `differentiated_cell_line` and `undifferentiated_product`:
- Added description for the `timepoint_unit` field