### PR TITLE
Moved properties to array of subschemas; Fixes #55

### DIFF
--- a/json_schema/type/protocol/gene_expression_alteration_protocol.json
+++ b/json_schema/type/protocol/gene_expression_alteration_protocol.json
@@ -63,6 +63,7 @@
           "title": "Gene edition",
           "items": {
             "title": "Gene edition",
+            "type": "object",
             "name": "gene_edition",
             "description": "Information about the gene edition in a protocol.",
             "required": ["altered_locus"],

--- a/json_schema/type/protocol/gene_expression_alteration_protocol.json
+++ b/json_schema/type/protocol/gene_expression_alteration_protocol.json
@@ -30,7 +30,6 @@
       "title": "Content",
       "required": [
         "label",
-        "altered_locus",
         "method"
       ],
       "properties": {
@@ -58,49 +57,136 @@
             "MSKKI119_MEF2C"
           ]
         },
-        "allele_specific": {
-          "type": "boolean",
-          "description": "Indicate if the technique used to modify expression of the gene is allele-specific.",
-          "title": "Allele-specific?",
-          "examples": [
-            false,
-            true
-          ]
-        },
-        "target_gene_symbol": {
-          "description": "Gene whose transcription was modified with this protocol.",
-          "title": "Target gene symbol",
-          "type": "string",
-          "minLength": 1,
-          "graphRestriction": {
-            "ontologies": [
-              "obo:ogg"
-            ],
-            "classes": [
-              "OGG:2000009606"
-            ],
-            "includeSelf": false,
-            "queryFields": [
-              "obo_id",
-              "label"
-            ]
-          },
-          "examples": [
-            "MEIS1",
-            "PAX6",
-            "OGG:3000005080"
-          ]
-        },
-        "target_gene_hgnc_id": {
-          "description": "HGNC gene identifier for the genes whose transcription was modified with this protocol. Please use HGNC gene identifiers.",
-          "title": "HGNC ID",
-          "type": "string",
-          "pattern": "^HGNC:\\d+$",
-          "minLength": 1,
-          "examples": [
-            "HGNC:7000",
-            "HGNC:6761"
-          ]
+        "gene_edition": {
+          "description": "Information about an array of gene edition objects.",
+          "type": "array",
+          "title": "Gene edition",
+          "items": {
+            "title": "Gene edition",
+            "name": "gene_edition",
+            "description": "Information about the gene edition in a protocol.",
+            "required": ["altered_locus"],
+            "properties": {
+              "allele_specific": {
+                "type": "boolean",
+                "description": "Indicate if the technique used to modify expression of the gene is allele-specific.",
+                "title": "Allele-specific?",
+                "examples": [
+                  false,
+                  true
+                ]
+              },
+              "target_gene_symbol": {
+                "description": "Gene whose transcription was modified with this protocol.",
+                "title": "Target gene symbol",
+                "type": "string",
+                "minLength": 1,
+                "graphRestriction": {
+                  "ontologies": [
+                    "obo:ogg"
+                  ],
+                  "classes": [
+                    "OGG:2000009606"
+                  ],
+                  "includeSelf": false,
+                  "queryFields": [
+                    "obo_id",
+                    "label"
+                  ]
+                },
+                "examples": [
+                  "MEIS1",
+                  "PAX6",
+                  "OGG:3000005080"
+                ]
+              },
+              "target_gene_hgnc_id": {
+                "description": "HGNC gene identifier for the genes whose transcription was modified with this protocol. Please use HGNC gene identifiers.",
+                "title": "HGNC ID",
+                "type": "string",
+                "pattern": "^HGNC:\\d+$",
+                "minLength": 1,
+                "examples": [
+                  "HGNC:7000",
+                  "HGNC:6761"
+                ]
+              },
+              "targeted_genomic_region": {
+                "type": "string",
+                "description": "Type of region that is targeted by the gene expression alteration protocol.",
+                "title": "Targeted genomic region",
+                "enum": [
+                  "exon",
+                  "intron",
+                  "promoter",
+                  "full coding region",
+                  "other"
+                ],
+                "examples": [
+                  "full coding region",
+                  "exon"
+                ]
+              },
+              "expected_alteration_type": {
+                "type": "string",
+                "description": "How the expression for the gene(s) was altered.",
+                "title": "Expected alteration type",
+                "enum": [
+                  "down-regulation",
+                  "up-regulation",
+                  "silencing"
+                ],
+                "examples": [
+                  "down-regulation",
+                  "up-regulation"
+                ]
+              },
+              "editing_strategy": {
+                "type": "string",
+                "description": "Editing strategy followed in the CRISPR protocol.",
+                "title": "Editing strategy",
+                "enum": [
+                  "full coding length",
+                  "critical exon",
+                  "termination codon"
+                ],
+                "examples": [
+                  "full coding length",
+                  "critical exon"
+                ]
+              },
+              "altered_locus": {
+                "type": "array",
+                "minItems": 1,
+                "description": "Genomic coordiantes relative to GRCh38 of any genomic alterations made.",
+                "title": "Altered locus",
+                "items": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^chr\\d\\d{0,1}:\\d+-\\d+$"
+                },
+                "examples": [
+                  "chr2:66437727-66464411",
+                  "chr5:88751722-88752302"
+                ]
+              },
+              "guide_sequence": {
+                "type": "array",
+                "minItems": 1,
+                "description": "Full nucleotide sequence(s) of guide sequences.",
+                "title": "Guide sequence(s)",
+                "items": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^[ACGT]+$"
+                },
+                "examples": [
+                  "AAAGTCGATGTATCTTCTAC",
+                  "TTGGTGATAGACGATAGAGAAG"
+                ]
+              }
+            }
+          }
         },
         "variation_type": {
           "type": "string",
@@ -340,50 +426,6 @@
             }
           }
         },
-        "targeted_genomic_region": {
-          "type": "string",
-          "description": "Type of region that is targeted by the gene expression alteration protocol.",
-          "title": "Targeted genomic region",
-          "enum": [
-            "exon",
-            "intron",
-            "promoter",
-            "full coding region",
-            "other"
-          ],
-          "examples": [
-            "full coding region",
-            "exon"
-          ]
-        },
-        "expected_alteration_type": {
-          "type": "string",
-          "description": "How the expression for the gene(s) was altered.",
-          "title": "Expected alteration type",
-          "enum": [
-            "down-regulation",
-            "up-regulation",
-            "silencing"
-          ],
-          "examples": [
-            "down-regulation",
-            "up-regulation"
-          ]
-        },
-        "editing_strategy": {
-          "type": "string",
-          "description": "Editing strategy followed in the CRISPR protocol.",
-          "title": "Editing strategy",
-          "enum": [
-            "full coding length",
-            "critical exon",
-            "termination codon"
-          ],
-          "examples": [
-            "full coding length",
-            "critical exon"
-          ]
-        },
         "method": {
           "type": "string",
           "minLength": 1,
@@ -406,36 +448,6 @@
             "CRISPR/Cas9 method",
             "BAO:0010249",
             "gene knockdown by lentiviral shRNA transduction"
-          ]
-        },
-        "altered_locus": {
-          "type": "array",
-          "minItems": 1,
-          "description": "Genomic coordiantes relative to GRCh38 of any genomic alterations made.",
-          "title": "Altered locus",
-          "items": {
-            "type": "string",
-            "minLength": 1,
-            "pattern": "^chr\\d\\d{0,1}:\\d+-\\d+$"
-          },
-          "examples": [
-            "chr2:66437727-66464411",
-            "chr5:88751722-88752302"
-          ]
-        },
-        "guide_sequence": {
-          "type": "array",
-          "minItems": 1,
-          "description": "Full nucleotide sequence(s) of guide sequences.",
-          "title": "Guide sequence(s)",
-          "items": {
-            "type": "string",
-            "minLength": 1,
-            "pattern": "^[ACGT]+$"
-          },
-          "examples": [
-            "AAAGTCGATGTATCTTCTAC",
-            "TTGGTGATAGACGATAGAGAAG"
           ]
         }
       }

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -21,7 +21,7 @@
         "sequence_file": "1.0.0"
       },
       "protocol": {
-        "gene_expression_alteration_protocol": "2.0.0"
+        "gene_expression_alteration_protocol": "3.0.0"
       }
     }
   }


### PR DESCRIPTION
For schema `type/protocol/gene_expression_alteration_protocol`:

Moved properties:

- ALLELE-SPECIFIC?
- ALTERED GENE SYMBOLS
- ALTERED GENE IDs
- TARGETED GENOMIC REGION
- EXPECTED ALTERATION TYPE
- EDITING STRATEGY
- ALTERED LOCUS (Required)
- GUIDE SEQUENCE

Under gene_editing property and made it an array
