### PR TITLE
Renamed expression alteration. Fixed typo on clonal cell line

### DIFF
--- a/json_schema/type/biomaterial/clonal_cell_line.json
+++ b/json_schema/type/biomaterial/clonal_cell_line.json
@@ -37,11 +37,11 @@
                     ]
                 },
                 "described_by": {
-                    "pattern": "^.*/type/[0-9]+.[0-9]+.[0-9]+/biomaterial/cell_line$"
+                    "pattern": "^.*/type/[0-9]+.[0-9]+.[0-9]+/biomaterial/clonal_cell_line$"
                 },
                 "schema_type": {
-                    "const": "cell_line",
-                    "default": "cell_line"
+                    "const": "clonal_cell_line",
+                    "default": "clonal_cell_line"
                 }
             }
         }

--- a/json_schema/type/protocol/expression_alteration.json
+++ b/json_schema/type/protocol/expression_alteration.json
@@ -15,11 +15,11 @@
       "$comment": "This loads the system needed properties outside the 'content' field. For implementation outside of MorPhiC, please ensure the system properties satisfy your implementation. These properties are not meant for the user to see.",
       "properties": {
         "described_by": {
-          "pattern": "^.*/type/[0-9]+.[0-9]+.[0-9]+/protocol/gene_expression_alteration_protocol$"
+          "pattern": "^.*/type/[0-9]+.[0-9]+.[0-9]+/protocol/expression_alteration$"
         },
         "schema_type": {
-          "const": "gene_expression_alteration_protocol",
-          "default": "gene_expression_alteration_protocol"
+          "const": "expression_alteration",
+          "default": "expression_alteration"
         }
       }
     }
@@ -57,7 +57,7 @@
             "MSKKI119_MEF2C"
           ]
         },
-        "gene_edition": {
+        "genes": {
           "description": "Information about an array of gene edition objects.",
           "type": "array",
           "title": "Gene edition",


### PR DESCRIPTION
For Gene expression alteration protocol schema:

- Renamed the file to expression alteration
- renamed the subschema "gene edition" to "Genes"

This fixes Issue #60 